### PR TITLE
Run screenshots through optipng before uploading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # travis wants a language so we make it feel special
 language: ruby
-before-script: 
+install: 
 - cabal update
 - cabal install shellcheck
 script: ~/.cabal/binshellcheck --format tty puush

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+# travis wants a language so we make it feel special
+language: ruby
+script: shellcheck --format tty puush
+addons:
+  apt:
+    packages:
+    - shellcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 # travis wants a language so we make it feel special
 language: ruby
-script: shellcheck --format tty puush
+before-script: 
+- cabal update
+- cabal install shellcheck
+script: ~/.cabal/binshellcheck --format tty puush
 addons:
   apt:
     packages:
-    - shellcheck
+    - cabal-install

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You do not need to specify the file name if you are going to use the script to t
 
 `puush -q myfile.png` - Upload an image and print the uploaded file URL to stdout without displaying desktop notifications.
 
-`env PUUSH_SCREENSHOT_DIR="$HOME/Pictures" PUUSH_DATE_FORMAT="%y-%m-%d_%H%M" puush -f` - Take a screenshot of the entire screen, store it in the 'Pictures' folder and use date format YY-MM-DD_HHMM for the filename.
+`env PUUSH_SCREENSHOT_DIR="$HOME/Pictures" PUUSH_DATE_FORMAT="%y-%m-%d_%H%M%S" puush -f` - Take a screenshot of the entire screen, store it in the '~/Pictures' folder and use date format yy-mm-dd_HHMMSS for the filename.
 
 ## Author & License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ puush4linux is a Linux client for the popular screenshot host [puush](http://puu
 
 **Arch Linux** users may install the [puush4linux package](https://aur.archlinux.org/packages/puush4linux/) from the AUR, packaged by [/u/some_random_guy_5345](https://www.reddit.com/user/some_random_guy_5345).
 
-1. Install dependencies: `bash`, `scrot`, `curl`, `xclip` and (optionally) `libnotify`.
+1. Install dependencies: `bash`, `scrot`, `curl`, and `xclip`; optionally: `libnotify` and `optipng`.
 2. Download the puush file and copy it to `/usr/bin`.
 3. Run `puush -l` in your terminal and enter your user name and password to log in.
 4. Set up shortcuts in your window manager/desktop environment to your liking.
@@ -34,6 +34,8 @@ You do not need to specify the file name if you are going to use the script to t
 `-w` - Take a screenshot of the active window and upload it.
 
 `-l` - (Re-)log in to puush with your username and password.
+
+`-b` - Don't optimize images with optipng; only applies when using `-afw` (Automatically disabled if optipng isn't found on the system)
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ puush4linux is a Linux client for the popular screenshot host [puush](http://puu
 
 **Arch Linux** users may install the [puush4linux package](https://aur.archlinux.org/packages/puush4linux/) from the AUR, packaged by [/u/some_random_guy_5345](https://www.reddit.com/user/some_random_guy_5345).
 
-1. Install dependencies: `bash`, `scrot`, `curl`, and `xclip`; optionally: `libnotify` and `optipng`.
+1. Install dependencies: `bash`, `scrot`, `curl`, and `xclip`; optionally: `libnotify`, `optipng`, `xdotool`, [maim](https://github.com/naelstrof/maim) and [slop](https://github.com/naelstrof/slop). If `maim` and `slop` are installed, maim is preferred over scrot when taking screenshots.
 2. Download the puush file and copy it to `/usr/bin`.
 3. Run `puush -l` in your terminal and enter your user name and password to log in.
 4. Set up shortcuts in your window manager/desktop environment to your liking.
@@ -31,17 +31,27 @@ You do not need to specify the file name if you are going to use the script to t
 
 `-f` - Take a screenshot of the entire screen and upload it.
 
-`-w` - Take a screenshot of the active window and upload it.
+`-w` - Take a screenshot of the active window and upload it. If using maim, `xdotool` is required.
 
 `-l` - (Re-)log in to puush with your username and password.
 
 `-b` - Don't optimize images with optipng; only applies when using `-afw` (Automatically disabled if optipng isn't found on the system)
+
+`-s` - Use scrot even if maim and slop are installed.
+
+### Optional environment variables
+
+`PUUSH_SCREENSHOT_DIR` - Directory in which to save screenshots. If defined, screenshots are not deleted after uploading. If not defined, "/tmp" is used.
+
+`PUUSH_DATE_FORMAT` - Date format for file name. See `man date` for information. Default is "%d-%m-%Y-%H%M%S".
 
 ### Examples
 
 `puush -c -a` - Take a screenshot of an area, upload it and put the link into the clipboard. (Equivalent to Ctrl+Shift+4 on Windows systems.)
 
 `puush -q myfile.png` - Upload an image and print the uploaded file URL to stdout without displaying desktop notifications.
+
+`env PUUSH_SCREENSHOT_DIR="$HOME/Pictures" PUUSH_DATE_FORMAT="%y-%m-%d_%H%M" puush -f` - Take a screenshot of the entire screen, store it in the 'Pictures' folder and use date format YY-MM-DD_HHMM for the filename.
 
 ## Author & License
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ puush4linux is a Linux client for the popular screenshot host [puush](http://puu
 
 ## Usage
 
-`puush <options> <filename>`
+`puush <options> [filename]`
 
 You do not need to specify the file name if you are going to use the script to take a screenshot.
 
 ### Options
 
-`-q` - Don't show any notifications on the desktop. (Automatically turned on if libnotify isn't found on the system.)
+`-q` - Don't show any notifications on the desktop. (Notifications are automatically disabled if libnotify isn't found on the system.)
 
 `-c` - Copy the URL of the uploaded file to X clipboard. If this is not specified, the URL will be sent to stdout.
 
@@ -45,20 +45,8 @@ You do not need to specify the file name if you are going to use the script to t
 
 ## Author & License
 
-Created by [Darwin](http://hpup.co) with ♥.
+Original version created by [Darwin](http://hpup.co) with ♥, licensed under the WTFPL v2
 
-```
-DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-            Version 2, December 2004
+This version is a fork of the original, and has been relicensed under the Apache License v2, see `LICENSE`.
 
-Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
-
-Everyone is permitted to copy and distribute verbatim or modified
-copies of this license document, and changing it is allowed as long
-as the name is changed.
-
-    DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
-
-0. You just DO WHAT THE FUCK YOU WANT TO.
-```
+WTFPL is *not* a legally or morally responsible license, which is why this fork won't be using it.

--- a/puush
+++ b/puush
@@ -35,6 +35,12 @@ function show_help {
 	exit 0
 }
 
+notify() {
+	if [[ $PUUSH_QUIET != 1 ]]; then
+		notify-send "$@"
+	fi
+}
+
 while getopts "h?qchafwlb" opt; do
     case "$opt" in
     h|\?)
@@ -61,12 +67,10 @@ done
 shift $((OPTIND-1))
 [ "$1" = "--" ] && shift
 
-PUUSH_FILE=$@
+PUUSH_FILE=$*
 
 # Disable notifications if notify-send is not available.
-if hash notify-send 2>/dev/null; then
-	PUUSH_QUIET=0
-else
+if hash notify-send 2>/dev/null; then true; else
 	PUUSH_QUIET=1
 fi
 
@@ -84,18 +88,18 @@ fi
 # Login logic
 if [[ "$PUUSH_SETUP" == 1 ]]; then
 	printf "puush.me username (email): "
-	read PUUSH_USER
+	read -r PUUSH_USER
 	printf "puush.me password: "
-	read -s PUUSH_PASSWORD
+	read -rs PUUSH_PASSWORD
 	echo ""
 
-	PUUSH_KEY=`curl "https://puush.me/api/auth" -s -F "e=$PUUSH_USER" -F "p=$PUUSH_PASSWORD" | sed -E 's/^.?,(\w+),.?,.+$/\1/'`
+	PUUSH_KEY=$(curl "https://puush.me/api/auth" -s -F "e=$PUUSH_USER" -F "p=$PUUSH_PASSWORD" | sed -E 's/^.?,(\w+),.?,.+$/\1/')
 	if [[ "$PUUSH_KEY" == "" ]] || [[ "$PUUSH_KEY" == "-1" ]]; then
 		echo "Authentication failed! Please try again."
 		exit 1
 	else
 		mkdir -p "$HOME/.config/puush4linux/"
-		echo $PUUSH_KEY > "$HOME/.config/puush4linux/api_key"
+		echo "$PUUSH_KEY" > "$HOME/.config/puush4linux/api_key"
 		echo "Authentication successful."
 	fi
 	exit
@@ -106,53 +110,50 @@ if [[ ! -e "$HOME/.config/puush4linux/api_key" ]]; then
 	if [[ $PUUSH_QUIET == 1 ]]; then
 		echo "API key is not set! Please run puush with the -l option to log in."
 	else
-		notify-send "Can't puush: API key is not set. Please run puush with the -l option to log in."
+		notify "Can't puush: API key is not set. Please run puush with the -l option to log in."
 	fi
 	exit 1
 else
-	PUUSH_KEY=`cat "$HOME/.config/puush4linux/api_key"`
+	PUUSH_KEY=$(cat "$HOME/.config/puush4linux/api_key")
 fi
 
 # Generate a file name
 if [[ -z $PUUSH_FILE ]]; then
-	PUUSH_FILE="/tmp/ss-`date '+%d-%m-%Y-%H%M%S'`.png"
+	PUUSH_FILE="/tmp/ss-$(date '+%d-%m-%Y-%H%M%S').png"
 fi
 
 # Take the screenshot if necessary.
 case $PUUSH_MODE in
-	a) scrot -b -q 90 -s $PUUSH_FILE;;
-	w) scrot -b -q 90 -u $PUUSH_FILE;;
-	f) scrot -b -q 90 $PUUSH_FILE;;
+	a) scrot -b -q 90 -s "$PUUSH_FILE";;
+	w) scrot -b -q 90 -u "$PUUSH_FILE";;
+	f) scrot -b -q 90 "$PUUSH_FILE";;
 esac
 
 # optimize image using optipng
 if [[ -n "$PUUSH_MODE" && $OPTIPNG_IMAGE = 1 ]]; then
-	optipng $PUUSH_OPTIPNG_OPTIONS -quiet $PUUSH_FILE
+	# shellcheck disable=2086
+	optipng $PUUSH_OPTIPNG_OPTIONS -quiet "$PUUSH_FILE"
 fi
 
 # Check if the screenshot was successful.
 # If not, notify the user and exit the program.
 if [[ ! -e "$PUUSH_FILE" ]]; then
-	if [[ $PUUSH_QUIET != 1 ]]; then
-		notify-send "File $PUUSH_FILE not found, upload cancelled. (mode: $PUUSH_MODE)"
-	fi
+	notify "File $PUUSH_FILE not found, upload cancelled. (mode: $PUUSH_MODE)"
 	exit 1
 fi
 # Notify the user that the upload is in progress.
 if [[ "$PUUSH_QUIET" != "1" ]]; then
-	notify-send --urgency=low "Uploading file..."
+	notify --urgency=low "Uploading file..."
 fi
 
 # Upload the screenshot.
 # Thanks github.com/blha303/puush-linux/ for assistance.
-PUUSH_URL=`curl "https://puush.me/api/up" -Ss -F "k=$PUUSH_KEY" -F "z=poop" -F "f=@$PUUSH_FILE" | sed -E 's/^.+,(.+),.+,.+$/\1\n/'`
+PUUSH_URL=$(curl "https://puush.me/api/up" -Ss -F "k=$PUUSH_KEY" -F "z=poop" -F "f=@$PUUSH_FILE" | sed -E 's/^.+,(.+),.+,.+$/\1\n/')
 
 if [[ "$PUUSH_URL" == "-1," ]]; then
-	if [[ $PUUSH_QUIET != 1 ]]; then
-		notify-send "Upload failed due to authentication failure."
-	fi
+		notify "Upload failed due to authentication failure."
 	if [[ ! -z $PUUSH_MODE ]]; then
-		rm $PUUSH_FILE
+		rm "$PUUSH_FILE"
 	fi
 	exit 1
 fi
@@ -162,24 +163,22 @@ if [[ "$PUUSH_URL" != http* ]]; then
 		notify-send "Upload failed. Check your internet connection."
 	fi
 	if [[ ! -z $PUUSH_MODE ]]; then
-		rm $PUUSH_FILE
+		rm "$PUUSH_FILE"
 	fi
 	exit 2
 fi
 
 if [[ $PUUSH_CLIP == 1 ]]; then
 	# Output the URL to the clipboard
-	echo $PUUSH_URL | xclip -i -selection clipboard
-	if [[ $PUUSH_QUIET != 1 ]]; then
-		notify-send "File uploaded and URL copied to clipboard."
-	fi
+	echo "$PUUSH_URL" | xclip -i -selection clipboard
+	notify "File uploaded and URL copied to clipboard."
 else
 	# Display the URL in the terminal.
-	echo $PUUSH_URL
+	echo "$PUUSH_URL"
 fi
 
 # Clean up the temporary screenshot file if it was temporary.
 
 if [[ ! -z $PUUSH_MODE ]]; then
-	rm $PUUSH_FILE
+	rm "$PUUSH_FILE"
 fi

--- a/puush
+++ b/puush
@@ -43,24 +43,24 @@ notify() {
 
 while getopts "h?qchafwlb" opt; do
     case "$opt" in
-    h|\?)
-        show_help
-        exit 0
+	    h|\?)
+	        show_help
+	        exit 0
         ;;
-    q)  PUUSH_QUIET=1
+	    q)  PUUSH_QUIET=1
         ;;
-	c)  PUUSH_CLIP=1
+			c)  PUUSH_CLIP=1
         ;;
-    a)  PUUSH_MODE=a
-		;;
-	f)  PUUSH_MODE=f
-		;;
-	w)	PUUSH_MODE=w
-		;;
-	l)	PUUSH_SETUP=1
-		;;
-	b)  OPTIPNG_IMAGE=0
-		;;
+	    a)  PUUSH_MODE=a
+				;;
+			f)  PUUSH_MODE=f
+				;;
+			w)	PUUSH_MODE=w
+				;;
+			l)	PUUSH_SETUP=1
+				;;
+			b)  OPTIPNG_IMAGE=0
+				;;
     esac
 done
 

--- a/puush
+++ b/puush
@@ -3,8 +3,9 @@
 # puush4linux v0.1
 # Bash client for the popular screenshot service puush.me
 # -------------------------------------------------------
-# Author: Darwin (http://hpup.co)
-# License: WTFPL, version 2
+# Original Author: Darwin (http://hpup.co)
+# Current Maintainer: Zeke Sonxx (https://github.com/zekesonxx)
+# License: Apache License v2
 
 
 # Read command line arguments.

--- a/puush
+++ b/puush
@@ -199,7 +199,7 @@ PUUSH_URL=$(curl "https://puush.me/api/up" -Ss -F "k=$PUUSH_KEY" -F "z=poop" -F 
 
 if [[ "$PUUSH_URL" == "-1," ]]; then
 		notify "Upload failed due to authentication failure."
-	if [[ ! -z $PUUSH_MODE ]]; then
+	if [[ ! -z $PUUSH_MODE && $PUUSH_SCREENSHOT_DIR == "/tmp" ]]; then
 		rm "$PUUSH_FILE"
 	fi
 	exit 1
@@ -209,7 +209,7 @@ if [[ "$PUUSH_URL" != http* ]]; then
 	if [[ $PUUSH_QUIET != 1 ]]; then
 		notify-send "Upload failed. Check your internet connection."
 	fi
-	if [[ ! -z $PUUSH_MODE ]]; then
+	if [[ ! -z $PUUSH_MODE && $PUUSH_SCREENSHOT_DIR == "/tmp" ]]; then
 		rm "$PUUSH_FILE"
 	fi
 	exit 2

--- a/puush
+++ b/puush
@@ -12,6 +12,7 @@ OPTIND=1
 
 PUUSH_QUIET=0 # Whether notifications via libnotify will be shown (default) or hidden.
 PUUSH_CLIP=0 # Whether the script will output to stdout (default) or the X clipboard.
+OPTIPNG_IMAGE=1 # Whether it will run a screenshotted image through optipng before uploading.
 
 sleep 0.2 # Fix for rogue WMs/DEs.
 
@@ -26,6 +27,7 @@ function show_help {
 	echo " -f 		Take a fullscreen screenshot and upload it."
 	echo " -w 		Take a screenshot of the active window and upload it."
 	echo " -l 		Log in to puush.me and save the API key."
+	echo " -b 		Don't run the image through optipng, only applies with -afw"
 	echo "Examples: "
 	echo " puush -c -a 	Take an area screenshot, upload it and put the URL into clipboard"
 	echo "		(emulates Ctrl+Shift+4 from the official version)"
@@ -33,7 +35,7 @@ function show_help {
 	exit 0
 }
 
-while getopts "h?qchafwl" opt; do
+while getopts "h?qchafwlb" opt; do
     case "$opt" in
     h|\?)
         show_help
@@ -51,6 +53,8 @@ while getopts "h?qchafwl" opt; do
 		;;
 	l)	PUUSH_SETUP=1
 		;;
+	b)  OPTIPNG_IMAGE=0
+		;;
     esac
 done
 
@@ -64,6 +68,11 @@ if hash notify-send 2>/dev/null; then
 	PUUSH_QUIET=0
 else
 	PUUSH_QUIET=1
+fi
+
+# Disable optipnging if there is no optipng
+if hash optipng 2>/dev/null; then true; else
+	OPTIPNG_IMAGE=0
 fi
 
 # Sanity check
@@ -115,6 +124,11 @@ case $PUUSH_MODE in
 	w) scrot -b -q 90 -u $PUUSH_FILE;;
 	f) scrot -b -q 90 $PUUSH_FILE;;
 esac
+
+# optimize image using optipng
+if [[ -n "$PUUSH_MODE" && $OPTIPNG_IMAGE = 1 ]]; then
+	optipng $PUUSH_OPTIPNG_OPTIONS -quiet $PUUSH_FILE
+fi
 
 # Check if the screenshot was successful.
 # If not, notify the user and exit the program.

--- a/puush
+++ b/puush
@@ -13,6 +13,18 @@ OPTIND=1
 PUUSH_QUIET=0 # Whether notifications via libnotify will be shown (default) or hidden.
 PUUSH_CLIP=0 # Whether the script will output to stdout (default) or the X clipboard.
 OPTIPNG_IMAGE=1 # Whether it will run a screenshotted image through optipng before uploading.
+PUUSH_XDOTOOL=0 # Needs to be installed for -w option when using maim.
+
+if type maim &> /dev/null && type slop &> /dev/null; then
+	# Prefer slop + maim over scrot if they are installed
+	PUUSH_USE_SCROT=0
+	if type xdotool &> /dev/null; then
+		# If xdotool is not installed, produce an error when using -w with maim
+		PUUSH_XDOTOOL=1
+	fi
+else
+	PUUSH_USE_SCROT=1
+fi
 
 sleep 0.2 # Fix for rogue WMs/DEs.
 
@@ -28,6 +40,7 @@ function show_help {
 	echo " -w 		Take a screenshot of the active window and upload it."
 	echo " -l 		Log in to puush.me and save the API key."
 	echo " -b 		Don't run the image through optipng, only applies with -afw"
+	echo " -s 		Use scrot even if maim and slop are installed."
 	echo "Examples: "
 	echo " puush -c -a 	Take an area screenshot, upload it and put the URL into clipboard"
 	echo "		(emulates Ctrl+Shift+4 from the official version)"
@@ -41,7 +54,7 @@ notify() {
 	fi
 }
 
-while getopts "h?qchafwlb" opt; do
+while getopts "h?qchafwlbs" opt; do
     case "$opt" in
     h|\?)
         show_help
@@ -61,8 +74,27 @@ while getopts "h?qchafwlb" opt; do
 		;;
 	b)  OPTIPNG_IMAGE=0
 		;;
+	s)  PUUSH_USE_SCROT=1
+		;;
     esac
 done
+
+# Optional env variables:
+#   PUUSH_SCREENSHOT_DIR # If defined, saves screenshots here
+#     Example: env PUUSH_SCREENSHOT_DIR="$HOME/Pictures/puush"
+#   PUUSH_DATE_FORMAT # If defined, will be used instead of the default date format
+#     Example (for yyyy-mm-dd-HHMMSS): env PUUSH_DATE_FORMAT="%Y-%m-%d-%H%M%S"
+#     See 'man date' for more information
+
+# If PUUSH_SCREENSHOT_DIR is undefined, use /tmp
+if [[ -z $PUUSH_SCREENSHOT_DIR || ! -d $PUUSH_SCREENSHOT_DIR ]]; then
+	PUUSH_SCREENSHOT_DIR="/tmp"
+fi
+
+# If PUUSH_DATE_FORMAT is undefined, use dd-mm-yyyy-HHMMSS (the old default value)
+if [[ -z $PUUSH_DATE_FORMAT ]]; then
+	PUUSH_DATE_FORMAT="%d-%m-%Y-%H%M%S"
+fi
 
 shift $((OPTIND-1))
 [ "$1" = "--" ] && shift
@@ -119,15 +151,29 @@ fi
 
 # Generate a file name
 if [[ -z $PUUSH_FILE ]]; then
-	PUUSH_FILE="/tmp/ss-$(date '+%d-%m-%Y-%H%M%S').png"
+	PUUSH_FILE="$PUUSH_SCREENSHOT_DIR/ss-$(date +$PUUSH_DATE_FORMAT).png"
 fi
 
 # Take the screenshot if necessary.
-case $PUUSH_MODE in
-	a) scrot -b -q 90 -s "$PUUSH_FILE";;
-	w) scrot -b -q 90 -u "$PUUSH_FILE";;
-	f) scrot -b -q 90 "$PUUSH_FILE";;
-esac
+if [[ "$PUUSH_USE_SCROT" == 1 ]]; then
+	# Take the screenshot using scrot
+	case $PUUSH_MODE in
+		a) scrot -b -q 90 -s "$PUUSH_FILE";;
+		w) scrot -b -q 90 -u "$PUUSH_FILE";;
+		f) scrot -b -q 90 "$PUUSH_FILE";;
+	esac
+else
+	# Take the screenshot using maim + slop
+	case $PUUSH_MODE in
+		a) maim -s "$PUUSH_FILE";;
+		w) if [[ "$PUUSH_XDOTOOL" == 1 ]]; then
+			maim -i $(xdotool getactivewindow) "$PUUSH_FILE"
+		else
+			notify "xdotool not installed, can't use -w with maim; use -s to use scrot instead."
+		fi;;
+		f) maim "$PUUSH_FILE";;
+	esac
+fi
 
 # optimize image using optipng
 if [[ -n "$PUUSH_MODE" && $OPTIPNG_IMAGE = 1 ]]; then
@@ -179,6 +225,6 @@ fi
 
 # Clean up the temporary screenshot file if it was temporary.
 
-if [[ ! -z $PUUSH_MODE ]]; then
+if [[ ! -z $PUUSH_MODE && $PUUSH_SCREENSHOT_DIR == "/tmp" ]]; then
 	rm "$PUUSH_FILE"
 fi

--- a/puush
+++ b/puush
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# puush4linux v0.1
+# puush4linux v1.0
 # Bash client for the popular screenshot service puush.me
 # -------------------------------------------------------
 # Original Author: Darwin (http://hpup.co)


### PR DESCRIPTION
scrot produces bloody huge files, which is fine, they just need to get optimized.

[108K optimized](https://puu.sh/oUczQ.png) vs [5.8MB unoptimized](https://puu.sh/oUd1C.png), visually and functionally identical.

Implemented to be quiet, won't affect ability to pipe output URL. Only applies to screenshots, if someone wants to upload an image manually they can optimize it themselves. Can be disabled with `-b`.

Also allows you to pass options to optipng with the `$PUUSH_OPTIPNG_OPTIONS` environment variable (so you can change the optimization level).
